### PR TITLE
Release 1.2.0

### DIFF
--- a/Carthage/MovableInkSDK.json
+++ b/Carthage/MovableInkSDK.json
@@ -8,5 +8,6 @@
   "1.0.0": "https://github.com/movableink/ios-sdk/releases/download/1.0.0/MovableInk.xcframework.zip",
   "1.0.1": "https://github.com/movableink/ios-sdk/releases/download/1.0.1/MovableInk.xcframework.zip",
   "1.0.2": "https://github.com/movableink/ios-sdk/releases/download/1.0.2/MovableInk.xcframework.zip",
-  "1.1.0": "https://github.com/movableink/ios-sdk/releases/download/1.1.0/MovableInk.xcframework.zip"
+  "1.1.0": "https://github.com/movableink/ios-sdk/releases/download/1.1.0/MovableInk.xcframework.zip",
+  "1.2.0": "https://github.com/movableink/ios-sdk/releases/download/1.2.0/MovableInk.xcframework.zip"
 }

--- a/MovableInk.podspec
+++ b/MovableInk.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "MovableInk"
-  s.version          = "1.1.0"
+  s.version          = "1.2.0"
   s.ios.deployment_target = "13.0"
   s.platform = :ios, "13.0"
   s.summary          = "MovableInk SDK"

--- a/Package.swift
+++ b/Package.swift
@@ -21,8 +21,8 @@ let package = Package(
   targets: [
    .binaryTarget(
      name: "MovableInk",
-     url: "https://github.com/movableink/ios-sdk/releases/download/1.1.0/MovableInk.xcframework.zip",
-     checksum: "f149bdb2c22f11fc55fe7c9204afcca38fd53d0fff111b24556abc25b77d7d0d"
+     url: "https://github.com/movableink/ios-sdk/releases/download/1.2.0/MovableInk.xcframework.zip",
+     checksum: "750b0066731afca7a7207efeefe11a4b08015e39c578dd65c55e658c34d3b8c2"
    ),
   ]
 )

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The MovableInk SDK requires iOS 13 and Swift 5.7 (Xcode 14) as a minimum.
 ```
 # Cartfile
 
-binary "https://raw.githubusercontent.com/movableink/ios-sdk/main/Carthage/MovableInkSDK.json" == 1.1.0
+binary "https://raw.githubusercontent.com/movableink/ios-sdk/main/Carthage/MovableInkSDK.json" == 1.2.0
 ```
 
 In the root of your project, run
@@ -37,7 +37,7 @@ $ carthage update --use-xcframeworks
 use_frameworks!
 
 target "YOUR_TARGET_NAME" do
-  pod "MovableInk", podspec: "https://raw.githubusercontent.com/movableink/ios-sdk/1.1.0/MovableInk.podspec"
+  pod "MovableInk", podspec: "https://raw.githubusercontent.com/movableink/ios-sdk/1.2.0/MovableInk.podspec"
 end
 ```
 


### PR DESCRIPTION
Adds support for adding an API Key and deeplink domains at runtime rather than in the info.plist if needed.