### PR TITLE
Release 1.7.0

### DIFF
--- a/Carthage/MovableInkSDK.json
+++ b/Carthage/MovableInkSDK.json
@@ -20,5 +20,6 @@
   "1.6.2": "https://github.com/movableink/ios-sdk/releases/download/1.6.2/MovableInk.xcframework.zip",
   "1.6.3": "https://github.com/movableink/ios-sdk/releases/download/1.6.3/MovableInk.xcframework.zip",
   "1.6.4": "https://github.com/movableink/ios-sdk/releases/download/1.6.4/MovableInk.xcframework.zip",
-  "1.6.5": "https://github.com/movableink/ios-sdk/releases/download/1.6.5/MovableInk.xcframework.zip"
+  "1.6.5": "https://github.com/movableink/ios-sdk/releases/download/1.6.5/MovableInk.xcframework.zip",
+  "1.7.0": "https://github.com/movableink/ios-sdk/releases/download/1.7.0/MovableInk.xcframework.zip"
 }

--- a/MovableInk.podspec
+++ b/MovableInk.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "MovableInk"
-  s.version          = "1.6.5"
+  s.version          = "1.7.0"
   s.ios.deployment_target = "13.0"
   s.platform = :ios, "13.0"
   s.summary          = "MovableInk SDK"

--- a/Package.swift
+++ b/Package.swift
@@ -21,8 +21,8 @@ let package = Package(
   targets: [
    .binaryTarget(
      name: "MovableInk",
-     url: "https://github.com/movableink/ios-sdk/releases/download/1.6.5/MovableInk.xcframework.zip",
-     checksum: "f5d5933b1201b0e866fcd7b5c7896ce821ca51248086578f847c7edc2298a748"
+     url: "https://github.com/movableink/ios-sdk/releases/download/1.7.0/MovableInk.xcframework.zip",
+     checksum: "541197c9472ec3b4cc51555018b876af6c7e4a171b562dd2e75ee58321d234cd"
    ),
   ]
 )

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The MovableInk SDK requires iOS 13 and Swift 5.7 (Xcode 14) as a minimum.
 ```
 # Cartfile
 
-binary "https://raw.githubusercontent.com/movableink/ios-sdk/main/Carthage/MovableInkSDK.json" == 1.6.5
+binary "https://raw.githubusercontent.com/movableink/ios-sdk/main/Carthage/MovableInkSDK.json" == 1.7.0
 ```
 
 In the root of your project, run
@@ -37,7 +37,7 @@ $ carthage update --use-xcframeworks
 use_frameworks!
 
 target "YOUR_TARGET_NAME" do
-  pod "MovableInk", podspec: "https://raw.githubusercontent.com/movableink/ios-sdk/1.6.5/MovableInk.podspec"
+  pod "MovableInk", podspec: "https://raw.githubusercontent.com/movableink/ios-sdk/1.7.0/MovableInk.podspec"
 end
 ```
 


### PR DESCRIPTION
* Swift 6 support
* Adds constraints for meta fields to match what the CDAPI actually accepts, i.e flat dictionary, no arrays or nested dictionaries, max of 20 items.
* Adds a new api to namespace events for better autocomplete.
  * Events are now available under `MIClient.events`, e.g `MIClient.events.productAdded(properties: ...)`
  * The old apis are still available, but we recommend using the apis namespaced under `events` as it's clearer to what these methods actually are. 
* More logging for behavior events with bad data, e.g logs error when a required value is blank.
* Deprecates `identifyUser` - api is no longer needed and it was confusing. 
  * `identifyUser` was used to attempt to associate events made as a guest user when becoming a known user.
  * The SDK will now internally perform this automatically when needed.
  * Please remove any usages as this api will be removed in an upcoming update.