### PR TITLE
Release 1.7.1

### DIFF
--- a/Carthage/MovableInkSDK.json
+++ b/Carthage/MovableInkSDK.json
@@ -21,5 +21,6 @@
   "1.6.3": "https://github.com/movableink/ios-sdk/releases/download/1.6.3/MovableInk.xcframework.zip",
   "1.6.4": "https://github.com/movableink/ios-sdk/releases/download/1.6.4/MovableInk.xcframework.zip",
   "1.6.5": "https://github.com/movableink/ios-sdk/releases/download/1.6.5/MovableInk.xcframework.zip",
-  "1.7.0": "https://github.com/movableink/ios-sdk/releases/download/1.7.0/MovableInk.xcframework.zip"
+  "1.7.0": "https://github.com/movableink/ios-sdk/releases/download/1.7.0/MovableInk.xcframework.zip",
+  "1.7.1": "https://github.com/movableink/ios-sdk/releases/download/1.7.1/MovableInk.xcframework.zip"
 }

--- a/MovableInk.podspec
+++ b/MovableInk.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "MovableInk"
-  s.version          = "1.7.0"
+  s.version          = "1.7.1"
   s.ios.deployment_target = "13.0"
   s.platform = :ios, "13.0"
   s.summary          = "MovableInk SDK"

--- a/Package.swift
+++ b/Package.swift
@@ -21,8 +21,8 @@ let package = Package(
   targets: [
    .binaryTarget(
      name: "MovableInk",
-     url: "https://github.com/movableink/ios-sdk/releases/download/1.7.0/MovableInk.xcframework.zip",
-     checksum: "541197c9472ec3b4cc51555018b876af6c7e4a171b562dd2e75ee58321d234cd"
+     url: "https://github.com/movableink/ios-sdk/releases/download/1.7.1/MovableInk.xcframework.zip",
+     checksum: "4d1817d1e98a0431345a548ad684d79d173a91d19814ad4d81a10325985b3913"
    ),
   ]
 )

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The MovableInk SDK requires iOS 13 and Swift 5.7 (Xcode 14) as a minimum.
 ```
 # Cartfile
 
-binary "https://raw.githubusercontent.com/movableink/ios-sdk/main/Carthage/MovableInkSDK.json" == 1.7.0
+binary "https://raw.githubusercontent.com/movableink/ios-sdk/main/Carthage/MovableInkSDK.json" == 1.7.1
 ```
 
 In the root of your project, run
@@ -37,7 +37,7 @@ $ carthage update --use-xcframeworks
 use_frameworks!
 
 target "YOUR_TARGET_NAME" do
-  pod "MovableInk", podspec: "https://raw.githubusercontent.com/movableink/ios-sdk/1.7.0/MovableInk.podspec"
+  pod "MovableInk", podspec: "https://raw.githubusercontent.com/movableink/ios-sdk/1.7.1/MovableInk.podspec"
 end
 ```
 


### PR DESCRIPTION
Resolves an issue where `storedDeeplinkSubject` was tied to the MainActor when it didn't need to be as Combine will handle this with `receive(on: DispatchQueue.main)` 